### PR TITLE
feat: 實作 AppBar 選單功能 (New Chat / Clear Chat / Copy All / About)

### DIFF
--- a/docs/features/20260416-02-16-07-development-opportunities.md
+++ b/docs/features/20260416-02-16-07-development-opportunities.md
@@ -1,0 +1,217 @@
+# AI-Chat 專案開發機會分析報告
+
+**生成時間**：2026-04-16 02:16:07  
+**分析方式**：3 個平行 Agent 從不同角度同時分析，最後彙整
+
+---
+
+## 分析架構
+
+| Agent | 負責面向 | 執行時間 |
+|-------|---------|---------|
+| **Agent 1** — 核心功能 & 架構 | 已實現功能、功能缺口、架構改進機會 | 124s |
+| **Agent 2** — UX & 行動平台 & CI/CD | 平台整合、CI/CD 差距、UX 優化 | 138s |
+| **Agent 3** — AI 能力 & 第三方整合 | AI 提供商、已實現 AI 功能、整合機會 | 93s |
+
+---
+
+## 現況總覽（3 Agent 共識）
+
+AI-Chat 是一個 **Firebase Gemini AI 驅動的單線程聊天應用**。架構清晰、BLoC 模式規範，但功能集中在基礎聊天，企業級能力明顯不足。
+
+**技術棧**：Flutter + Firebase AI (Gemini 2.5 Flash) + ObjectBox + BLoC + GetIt
+
+---
+
+## Agent 1：核心功能 & 架構分析
+
+### 已實現功能
+
+- **Gemini 2.5 Flash** 串流回應（`firebase_ai: ^3.9.0`）
+- **多媒體支援**：圖片（Base64）+ 檔案（上限 5MB）
+- **ObjectBox 本地持久化**：最多 100 筆訊息，重啟後可還原（文字部分）
+- **Markdown 渲染**：`flutter_markdown ^0.7.7+1`，含程式碼區塊
+- **BLoC 狀態管理**：7 個精細化 Status enum
+- **多語言**：繁中 (zh_TW) + 英文
+- **DI 框架**：GetIt Service Locator
+
+### 功能缺口（有代碼證據）
+
+#### 1. 多對話會話管理（高優先級）
+- `ChatMessage` entity 缺少 `sessionId`、`sessionTitle` 欄位
+- `ChatRepository` 只有全局 `_chatList`，無會話隔離
+- 設計文件 `docs/plans/20-objectbox-chat-cache-design.md` 第 388-393 行明確標為「YAGNI 範圍外」
+- **建議**：新增 `ChatSession` Entity + 修改 `ChatRepository` 加入 `createSession()`、`switchSession()`
+
+#### 2. 設定面板（高優先級）
+- `ai_chat_view.dart` line 71-74：Menu IconButton `onPressed: () {}` 完全空白
+- 無溫度（temperature）、TopP、模型版本等 API 參數調整
+- 主題寫死為單一 `colorScheme.fromSeed()`
+- **建議**：新建 `SettingsBloc` + `SettingsPage`，用 SharedPreferences 儲存偏好
+
+#### 3. 附件本地化儲存（中優先級）
+- `_stripBase64()` 方法（`chat_repository.dart` line 240-247）把圖片 Base64 替換為文字佔位符
+- App 重啟後圖片無法還原
+- **建議**：新增 `ChatAttachment` Entity，使用 `path_provider` 存入應用沙箱
+
+#### 4. 對話搜尋與匯出（中優先級）
+- `ChatRepository` 只有 `loadMessages()` 和 `saveMessage()`，無查詢功能
+- **建議**：新增 `searchMessages(String query)`、`exportChat(session, format)`
+
+#### 5. 錯誤恢復與重試（中優先級）
+- `Status.noInternetConnection` 定義但從未被觸發
+- 無離線佇列機制
+- **建議**：指數退避重試 + `connectivity_plus` 離線偵測
+
+### 架構改進機會
+
+| 項目 | 現況問題 | 建議方向 |
+|------|---------|---------|
+| `GeminiApiBloc` | 混合模型初始化、檔案選取、訊息發送 | 抽出 `FilePickerBloc` 獨立管理 |
+| `ChatRepository` | 無分頁、無事件流 | 加入 `loadMessages(page, pageSize)` + Stream |
+| DI 層 | 只有 `ChatRepository` 在 `injection.dart` | 補上 `GeminiService`、`PreferencesRepository`、`ConnectivityService` |
+| 連線層 | 直接在 Bloc 呼叫 Firebase AI | 新建 `GeminiService` 抽象介面，封裝重試與流量控制 |
+
+---
+
+## Agent 2：UX & 行動平台 & CI/CD 分析
+
+### 已實現的平台功能
+
+**iOS**
+- Firebase 4 環境配置（Dev / Beta / Prod）
+- 相片庫 `NSPhotoLibraryUsageDescription` 權限宣告
+- Fastlane ad-hoc 自動化（`local_build`、`beta_build`、`beta_deploy`）
+
+**Android**
+- `READ_MEDIA_IMAGES` + `READ_EXTERNAL_STORAGE` 權限宣告
+- Kotlin 1.7+ / Java 17 Gradle 配置
+- Firebase Google Play Services
+
+### 缺失的平台功能
+
+| 功能 | iOS | Android | 影響 |
+|------|-----|---------|------|
+| 推送通知（FCM） | ❌ | ❌ | 無法提醒用戶 AI 回覆完成 |
+| 深連結（Deep Linking） | ❌ | ❌ | 無法從外部跳轉到特定對話 |
+| 後台處理 | ❌ | ❌ | 無離線同步或後台 AI 任務 |
+| 生物辨識鎖定 | ❌ | ❌ | 無隱私保護 |
+| App Shortcuts / App Links | ❌ | ❌ | 快速操作入口缺失 |
+| 訊息分享 | ❌ | ❌ | 無法分享對話記錄 |
+| 暗色模式完整支援 | ⚠️ | ⚠️ | `main.dart` 無 `ThemeData.dark()` |
+
+### CI/CD 缺口
+
+| 項目 | 狀態 | 建議 |
+|------|------|------|
+| **GitHub Actions** | ❌ 無 `.github/workflows/` | 建立自動化測試 + 構建 + 發布流程 |
+| **Android Fastlane** | ❌ 無 | 對稱 iOS，實現自動簽名 + Firebase Distribution |
+| **自動化測試 in CI** | ⚠️ test 目錄存在但幾乎空 | 加入 widget / integration test CI gate |
+| **版本自動化** | ⚠️ 手動 | 無自動版本 bump、Changelog 生成 |
+| **代碼品質掃描** | ❌ 無 | SonarQube 或 GitHub CodeQL |
+| **App Store / Google Play 發行** | ❌ 無 | 只有 Firebase Distribution，缺正式商店上架流程 |
+
+### UX 改進空間
+
+| 項目 | 現況 | 建議 |
+|------|------|------|
+| 聊天搜尋 | ❌ 無 | `SearchDelegate` 搜尋歷史訊息 |
+| 多對話支援 | ❌ 單線程 | 對話列表 + 快速切換 |
+| 訊息長按選單 | ⚠️ 僅複製 | 加入分享、收藏、刪除 |
+| 草稿自動儲存 | ❌ 無 | 自動儲存未發送輸入 |
+| 語音輸入/輸出 | ❌ 無 | `speech_to_text` + `flutter_tts` |
+| 骨架屏 / 漸進式載入 | ⚠️ 簡單旋轉 | Shimmer 效果提升感知效能 |
+| 動畫過渡 | ⚠️ 基礎 | Material 3 精緻頁面切換動畫 |
+
+---
+
+## Agent 3：AI 能力 & 第三方整合分析
+
+### 目前整合的 AI 提供商
+
+- **唯一提供商**：Google Gemini（透過 `firebase_ai: ^3.9.0`）
+- **模型**：硬編碼為 `gemini-2.5-flash`（`gemini_api_bloc.dart` 第 188 行）
+- **整合方式**：Firebase AI Logic（`_initFirebaseAiLogic()` 第 186-195 行）
+
+### 已實現的 AI 功能
+
+| 功能 | 狀態 | 位置 |
+|------|------|------|
+| 串流回應 | ✅ | `gemini_api_bloc.dart` 第 80-117 行 |
+| 多模態輸入（文字 + 圖片 + 檔案） | ✅ | 第 196-225 行 |
+| 多種回應內容解析（Text/Code/InlineData） | ✅ | 第 87-101 行 |
+| Markdown 渲染 | ✅ | `message_bubble_widget.dart` |
+| 本地持久化 | ✅ | `chat_repository.dart` |
+
+### 明顯缺失的 AI 功能
+
+| 功能 | 說明 |
+|------|------|
+| **函數調用（Function Calling）** | 完全未實現，無法讓 AI 主動調用 App 功能 |
+| **對話上下文管理** | 每次請求獨立，不傳送對話歷史，AI 無記憶 |
+| **模型選擇與切換** | 硬編碼，無法在 runtime 切換 Gemini 版本 |
+| **提示詞工程** | 提示硬編碼（第 219-236 行），無範本系統 |
+| **多 AI 提供商支援** | 無 OpenAI / Anthropic Claude / LLaMA 等 |
+| **RAG（檢索增強生成）** | 無向量資料庫、無本地知識庫 |
+
+### 第三方整合現狀
+
+**已整合（但未完整使用）**
+
+| 套件 | 用途 | 備註 |
+|------|------|------|
+| `firebase_app_check` | 安全驗證 | 已安裝，未啟用 |
+| `firebase_auth` 相關 | 身份驗證 | DI 有位置預留但未實現 |
+
+**明顯缺失的整合**
+
+| 類別 | 建議整合 | 用途 |
+|------|---------|------|
+| 身份驗證 | Firebase Auth | 用戶帳號 + 跨設備同步 |
+| 雲端資料庫 | Firestore | 跨設備聊天記錄同步 |
+| 錯誤追蹤 | Firebase Crashlytics | 生產環境 crash 監控 |
+| 向量資料庫 | Pinecone / Supabase Vector | RAG 知識庫 |
+| 搜尋引擎 | Typesense / Elasticsearch | 語義搜尋 |
+
+---
+
+## 綜合開發路線圖
+
+### 短期（1-2 週）— 高影響、低複雜度
+
+1. **設定面板** — 解鎖空白的 Menu 按鈕，實現模型選擇、溫度調整、暗色模式
+2. **GitHub Actions 基礎流程** — Flutter test + build，自動觸發 Fastlane beta
+3. **對話上下文傳送** — 在 `GeminiApiBloc` 傳送完整歷史，讓 AI 有記憶
+
+### 中期（3-4 週）— 核心體驗提升
+
+4. **多對話會話管理** — `ChatSession` Entity + 對話列表頁面
+5. **推送通知（FCM）** — Firebase 已就緒，加入 `firebase_messaging`
+6. **Android Fastlane** — 對稱 iOS，建立 Android beta 自動化
+7. **訊息搜尋** — `ChatRepository.searchMessages()` + 搜尋 UI
+
+### 長期（1-2 月）— 能力升級
+
+8. **多模型支援** — 建立 `AIProviderAbstraction`，支援 Gemini Pro / Flash 切換
+9. **Function Calling / Tool Use** — 讓 AI 調用 App 原生功能
+10. **RAG 知識庫** — 向量資料庫整合，支援文件問答
+11. **Firebase Auth + Firestore 同步** — 用戶帳號 + 跨設備資料同步
+12. **附件本地快取** — `ChatAttachment` Entity + 圖片庫查看
+
+---
+
+## 優先級矩陣
+
+| 功能 | 影響力 | 複雜度 | 建議順序 |
+|------|--------|--------|---------|
+| 設定面板 | 高 | 低 | ⭐ 第 1 |
+| GitHub Actions CI | 高 | 低 | ⭐ 第 2 |
+| 對話上下文傳送 | 高 | 低 | ⭐ 第 3 |
+| 多對話會話 | 高 | 中 | ⭐ 第 4 |
+| 推送通知 | 中 | 低 | 第 5 |
+| Android Fastlane | 中 | 低 | 第 6 |
+| 訊息搜尋 | 中 | 中 | 第 7 |
+| 多模型支援 | 高 | 中 | 第 8 |
+| Function Calling | 高 | 高 | 第 9 |
+| RAG 系統 | 高 | 高 | 第 10 |
+| Firebase Auth + 同步 | 中 | 高 | 第 11 |

--- a/docs/features/20260416-02-25-37-menu-feature-spec.md
+++ b/docs/features/20260416-02-25-37-menu-feature-spec.md
@@ -1,0 +1,355 @@
+# Menu 功能規格文件
+
+**日期**：2026-04-16  
+**狀態**：待實作  
+**範圍**：`ios/` AppBar `more_vert` IconButton 功能實作
+
+---
+
+## 背景
+
+`ai_chat_view.dart` line 71-74 有一個空白的 `more_vert` IconButton，`onPressed: () {}` 完全未實作。本規格定義此 Menu 的完整功能集、UI 行為與實作細節。
+
+---
+
+## 功能清單
+
+4 個 Menu 項目，按使用頻率排序：
+
+| # | 項目 | 說明 | 複雜度 |
+|---|------|------|--------|
+| 1 | **新對話** (New Chat) | 清空畫面，開啟全新對話 | 低 |
+| 2 | **清除對話** (Clear Chat) | 清空畫面 + 清除 ObjectBox 所有記錄 | 低 |
+| 3 | **複製對話** (Copy All) | 將所有訊息格式化後複製到剪貼簿 | 低 |
+| 4 | **關於** (About) | 顯示 App 版本、模型名稱 | 低 |
+
+---
+
+## UI 規格
+
+### Menu 呈現方式
+
+使用 Flutter 原生 `showMenu()` 或 `PopupMenuButton`，點擊 `more_vert` icon 後從右上角展開。
+
+```
+┌─────────────────┐
+│ ✦ 新對話        │
+│ 🗑 清除對話     │
+│ 📋 複製對話     │
+│ ─────────────── │
+│ ℹ  關於         │
+└─────────────────┘
+```
+
+- 「關於」與其他項目之間加 `Divider`
+- 使用 `PopupMenuButton<_MenuAction>` enum 驅動，避免 magic string
+
+---
+
+## 各功能規格
+
+### 1. 新對話（New Chat）
+
+**行為**：
+- 清空畫面訊息列表（UI 回到 `EmptyWidget`）
+- **不刪除** ObjectBox 記錄（歷史訊息永久保留於 DB）
+- 將當下時間戳寫入 SharedPreferences（key: `session_start_ms`）作為新 session 邊界
+- 重置 BLoC 狀態：`chatList = null`、清除已選附件
+- **重啟 App 後**：`_init` 只載入 `timestamp > session_start_ms` 的訊息，因此舊訊息不會重新出現
+
+**Session 載入規則**：
+
+| SharedPreferences `session_start_ms` | `_init` 行為 |
+|--------------------------------------|-------------|
+| 不存在（從未點過新對話）| 載入全部訊息 |
+| 存在（值為 T）| 只載入 `timestamp > T` 的訊息 |
+
+**觸發路徑**：
+```
+Menu tap → GeminiApiNewChatEvent → BLoC._newChat()
+  → SharedPreferences.setInt('session_start_ms', now)
+  → emit(state.copyWith(chatList: null, clearFile: true))
+```
+
+**依賴套件**：`shared_preferences`（需新增至 `pubspec.yaml`）
+
+**新增事件**：
+```dart
+// gemini_api_event.dart
+class GeminiApiNewChatEvent extends GeminiApiEvent {}
+```
+
+**BLoC handler**：
+```dart
+on<GeminiApiNewChatEvent>(_newChat);
+
+Future<void> _newChat(GeminiApiNewChatEvent event, Emitter<GeminiApiState> emit) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setInt('session_start_ms', DateTime.now().millisecondsSinceEpoch);
+  _chatList = [];
+  emit(state.copyWith(
+    status: Status.initial,
+    chatList: null,
+    clearFile: true,
+  ));
+}
+```
+
+**`_init` 調整**（配合 session 邊界）：
+```dart
+void _init(GeminiApiInitEvent event, Emitter<GeminiApiState> emit) async {
+  final prefs = await SharedPreferences.getInstance();
+  final sessionStartMs = prefs.getInt('session_start_ms'); // null → 首次安裝
+
+  _chatList = _repo.loadMessages(since: sessionStartMs).map((m) { ... }).toList();
+  ...
+}
+```
+
+---
+
+### 2. 清除對話（Clear Chat）
+
+**行為**：
+- 顯示確認 Dialog（防止誤操作）
+- 確認後：清空 ObjectBox 所有記錄 + 清空畫面
+
+**確認 Dialog**：
+```
+標題：清除所有對話？
+內容：此操作無法復原，所有對話記錄將被永久刪除。
+按鈕：取消 | 清除（紅色）
+```
+
+**觸發路徑**：
+```
+Menu tap → showDialog() → 確認 → GeminiApiClearAllEvent → BLoC._clearAll()
+```
+
+**ChatRepository 調整**：
+```dart
+// abstract interface class ChatRepository
+// loadMessages 新增 since 參數（null → 載入全部）
+List<ChatMessage> loadMessages({int? since});
+void clearAll();
+
+// ChatRepo 實作
+@override
+List<ChatMessage> loadMessages({int? since}) {
+  final query = since != null
+      ? _box.query(ChatMessage_.timestamp.greaterThan(since))
+            .order(ChatMessage_.timestamp, flags: Order.descending)
+            .build()
+      : _box.query()
+            .order(ChatMessage_.timestamp, flags: Order.descending)
+            .build()
+    ..limit = _maxMessages;
+  try {
+    return query.find();
+  } finally {
+    query.close();
+  }
+}
+
+@override
+void clearAll() => _box.removeAll();
+```
+
+**新增事件**：
+```dart
+class GeminiApiClearAllEvent extends GeminiApiEvent {}
+```
+
+**BLoC handler**：
+```dart
+on<GeminiApiClearAllEvent>(_clearAll);
+
+void _clearAll(GeminiApiClearAllEvent event, Emitter<GeminiApiState> emit) {
+  _repo.clearAll();
+  _chatList = [];
+  emit(state.copyWith(
+    status: Status.initial,
+    chatList: null,
+    clearFile: true,
+  ));
+}
+```
+
+---
+
+### 3. 複製對話（Copy All）
+
+**行為**：
+- 將 `state.chatList` 格式化為純文字
+- 用 `Clipboard.setData()` 複製
+- 顯示 `SnackBar` 確認提示：「已複製對話記錄」
+
+**格式化規則**：
+- 每條訊息前綴已由 `ChatEntryPrefix` 包裝（`[PROMPT]`、`[AI_REPLY]`、`[ERROR]`）
+- 輸出時轉換為可讀前綴：
+  - `[PROMPT]` → `👤 You:`
+  - `[AI_REPLY]` → `🤖 Gemini:`
+  - `[ERROR]` → `⚠️ Error:`
+- 訊息間以空行分隔
+
+**不需要新 BLoC event**，直接在 widget 層處理：
+```dart
+void _copyAllMessages(BuildContext context, List<String> chatList) {
+  final buffer = StringBuffer();
+  // chatList 是 newest-first，複製時 reversed 為時間順序
+  for (final msg in chatList.reversed) {
+    final readable = msg
+        .replaceFirst('[PROMPT]', '👤 You:')
+        .replaceFirst('[AI_REPLY]', '🤖 Gemini:')
+        .replaceFirst('[ERROR]', '⚠️ Error:');
+    buffer.writeln(readable);
+    buffer.writeln();
+  }
+  Clipboard.setData(ClipboardData(text: buffer.toString()));
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text(S.current.copiedToClipboard)),
+  );
+}
+```
+
+---
+
+### 4. 關於（About）
+
+**行為**：
+- 顯示 `AboutDialog` 或自訂底部 Sheet
+- 顯示資訊：App 名稱、版本、目前使用的 AI 模型
+
+**顯示內容**：
+```
+AI Chat
+版本 1.0.0 (build 1)
+
+AI 模型：Gemini 2.5 Flash
+提供商：Google Firebase AI
+```
+
+**版本取得方式**：使用 `package_info_plus` 套件（需新增依賴）
+
+```dart
+// pubspec.yaml 新增
+package_info_plus: ^8.1.2
+
+// 使用
+final info = await PackageInfo.fromPlatform();
+// info.version → "1.0.0"
+// info.buildNumber → "1"
+```
+
+**替代方案（不加套件）**：直接硬編碼版本字串常數，下次改版時手動更新。建議先用此方式，避免增加依賴。
+
+```dart
+// lib/features/foundation/constants/app_constants.dart（新增）
+class AppConstants {
+  const AppConstants._();
+  static const appVersion = '1.0.0';
+  static const buildNumber = '1';
+  static const aiModel = 'Gemini 2.5 Flash';
+  static const aiProvider = 'Google Firebase AI';
+}
+```
+
+---
+
+## i18n 字串新增
+
+### `intl_zh_TW.arb`
+
+```json
+"menuNewChat": "新對話",
+"menuClearChat": "清除對話",
+"menuCopyAll": "複製對話",
+"menuAbout": "關於",
+"clearChatTitle": "清除所有對話？",
+"clearChatContent": "此操作無法復原，所有對話記錄將被永久刪除。",
+"clearChatConfirm": "清除",
+"copiedToClipboard": "已複製對話記錄",
+"aboutDialogVersion": "版本 {version} (build {build})",
+"@aboutDialogVersion": {
+  "placeholders": {
+    "version": { "type": "String" },
+    "build": { "type": "String" }
+  }
+},
+"aboutDialogModel": "AI 模型：{model}",
+"@aboutDialogModel": {
+  "placeholders": {
+    "model": { "type": "String" }
+  }
+}
+```
+
+### `intl_en.arb`
+
+```json
+"menuNewChat": "New Chat",
+"menuClearChat": "Clear Chat",
+"menuCopyAll": "Copy All",
+"menuAbout": "About",
+"clearChatTitle": "Clear all messages?",
+"clearChatContent": "This action cannot be undone. All conversation history will be permanently deleted.",
+"clearChatConfirm": "Clear",
+"copiedToClipboard": "Conversation copied",
+"aboutDialogVersion": "Version {version} (build {build})",
+"@aboutDialogVersion": {
+  "placeholders": {
+    "version": { "type": "String" },
+    "build": { "type": "String" }
+  }
+},
+"aboutDialogModel": "AI Model: {model}",
+"@aboutDialogModel": {
+  "placeholders": {
+    "model": { "type": "String" }
+  }
+}
+```
+
+---
+
+## 受影響的檔案
+
+| 檔案 | 異動類型 | 說明 |
+|------|---------|------|
+| `lib/pages/widgets/ai_chat_view.dart` | 修改 | 實作 `PopupMenuButton`，加入 4 個 menu 項目 |
+| `lib/bloc/gemini_api/gemini_api_event.dart` | 修改 | 新增 `GeminiApiNewChatEvent`、`GeminiApiClearAllEvent` |
+| `lib/bloc/gemini_api/gemini_api_bloc.dart` | 修改 | 新增 `_newChat`、`_clearAll` handler；調整 `_init` 支援 session 邊界 |
+| `lib/data/chat_repository.dart` | 修改 | `loadMessages` 加 `since` 參數；新增 `clearAll()` interface + 實作 |
+| `lib/l10n/intl_zh_TW.arb` | 修改 | 新增 8 個字串 |
+| `lib/l10n/intl_en.arb` | 修改 | 新增 8 個字串 |
+| `lib/features/foundation/constants/app_constants.dart` | 新增 | App 版本、模型名稱常數 |
+| `pubspec.yaml` | 修改 | 新增 `shared_preferences` 依賴 |
+
+---
+
+## 實作順序
+
+```
+1. pubspec.yaml                ← 新增 shared_preferences 依賴
+2. app_constants.dart          ← 無依賴，先建
+3. chat_repository.dart        ← loadMessages 加 since 參數；加 clearAll()
+4. gemini_api_event.dart       ← 加 2 個 Event
+5. gemini_api_bloc.dart        ← 調整 _init 支援 session 邊界；加 _newChat、_clearAll handler
+6. intl_zh_TW.arb / intl_en.arb ← 加 i18n 字串
+7. make intl                   ← 重新生成 l10n
+8. ai_chat_view.dart           ← 最後實作 UI
+```
+
+---
+
+## 驗證清單
+
+- [ ] 點擊 `more_vert` 顯示 4 個選項
+- [ ] 新對話：畫面清空，DB 資料保留
+- [ ] 新對話：重啟 App 後，舊訊息不會出現（session 時間戳正確寫入 SharedPreferences）
+- [ ] 清除對話：Dialog 出現 → 取消不刪除 → 確認後清空畫面 + DB
+- [ ] 複製對話：SnackBar 出現，剪貼簿內容格式正確（時間順序、前綴可讀）
+- [ ] 複製對話：chatList 為空時，複製結果為空字串，SnackBar 仍出現
+- [ ] 關於：版本號與 `pubspec.yaml` 一致
+- [ ] 所有文字符合 zh_TW / en 雙語
+- [ ] `make analyze_lint` 無新增警告

--- a/docs/plans/2026-04-26-appbar-more-menu-plan.md
+++ b/docs/plans/2026-04-26-appbar-more-menu-plan.md
@@ -1,0 +1,860 @@
+# AppBar more_vert Menu Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 實作 `ai_chat_view.dart` AppBar 內 `more_vert` IconButton 的 4 個 menu 項目（New Chat / Clear Chat / Copy All / About），讓使用者能管理對話 session、複製對話、查看 App 資訊。
+
+**Architecture:** 採 BLoC 事件驅動：UI 觸發 menu → dispatch event → BLoC 操作 `ChatRepository` 與 SharedPreferences → emit 新 state。「新對話」用 `session_start_ms` 時間戳寫入 SharedPreferences 作為 session 邊界，`_init` 載入訊息時根據此時間戳過濾。
+
+**Tech Stack:** Flutter / Dart / flutter_bloc / ObjectBox / shared_preferences / intl_utils
+
+**Spec Reference:** `docs/features/20260416-02-25-37-menu-feature-spec.md`
+
+**Pre-existing Code Notes（避免錯誤假設）:**
+- `ChatEntryPrefix` 實際前綴是 `'Prompt: '`、`'AI reply: '`、`'Error: '`，**非** spec 寫的 `[PROMPT]` / `[AI_REPLY]` / `[ERROR]`。轉換時用 `ChatEntryPrefix.strip()`。
+- `_chatList` 為 newest-first（最新訊息在 index 0），複製時要 `reversed` 才是時間順序。
+- `_init` 目前是 `async` 但用 `void` 回傳；新版改為 `Future<void>` 以正確 await SharedPreferences。
+- `ChatMessage.timestamp` 型別為 `int`（millisecondsSinceEpoch）。
+
+---
+
+## Task 1: 新增 `shared_preferences` 依賴
+
+**Files:**
+- Modify: `pubspec.yaml`（在 `dependencies:` 區塊）
+
+**Step 1: 在 pubspec.yaml 新增依賴**
+
+在 `collection: ^1.19.1` 之後新增：
+
+```yaml
+  shared_preferences: ^2.3.3
+```
+
+**Step 2: 執行 pub get**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && flutter pub get`
+Expected: `Got dependencies!` 且無錯誤
+
+**Step 3: 確認 import 可解析**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart -e "import 'package:shared_preferences/shared_preferences.dart';"` 失敗也沒關係，主要看 pub get 是否成功。
+
+執行：`cd /Users/yomiry/AiWorkspace/AI-Chat && grep shared_preferences pubspec.lock | head -3`
+Expected: 出現 `shared_preferences:` entry
+
+**Step 4: Commit**
+
+```bash
+git add pubspec.yaml pubspec.lock
+git commit -m "chore: add shared_preferences dependency for session boundary"
+```
+
+---
+
+## Task 2: 建立 `app_constants.dart`
+
+**Files:**
+- Create: `lib/features/foundation/constants/app_constants.dart`
+- Modify: `lib/features/foundation/foundation.dart`（加 export）
+- Test: `test/app_constants_test.dart`
+
+**Step 1: 寫失敗測試**
+
+建立 `test/app_constants_test.dart`：
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ai_chat/features/foundation/constants/app_constants.dart';
+
+void main() {
+  group('AppConstants', () {
+    test('appVersion is non-empty', () {
+      expect(AppConstants.appVersion, isNotEmpty);
+    });
+
+    test('buildNumber is non-empty', () {
+      expect(AppConstants.buildNumber, isNotEmpty);
+    });
+
+    test('aiModel is non-empty', () {
+      expect(AppConstants.aiModel, isNotEmpty);
+    });
+
+    test('aiProvider is non-empty', () {
+      expect(AppConstants.aiProvider, isNotEmpty);
+    });
+
+    test('cannot be instantiated', () {
+      // const private constructor — 編譯時就限制；此處純文件用。
+      expect(AppConstants.appVersion, equals('1.0.0'));
+      expect(AppConstants.buildNumber, equals('1'));
+    });
+  });
+}
+```
+
+**Step 2: 執行測試確認失敗**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && flutter test test/app_constants_test.dart`
+Expected: FAIL（檔案不存在 / import 找不到）
+
+**Step 3: 建立 `app_constants.dart`**
+
+建立 `lib/features/foundation/constants/app_constants.dart`：
+
+```dart
+class AppConstants {
+  const AppConstants._();
+
+  static const String appVersion = '1.0.0';
+  static const String buildNumber = '1';
+  static const String aiModel = 'Gemini 2.5 Flash';
+  static const String aiProvider = 'Google Firebase AI';
+}
+```
+
+**Step 4: 在 foundation barrel 加 export**
+
+修改 `lib/features/foundation/foundation.dart`：
+
+```dart
+export 'constants/app_constants.dart';
+export 'extension/extensions.dart';
+export 'style/style.dart';
+```
+
+**Step 5: 執行測試確認通過**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && flutter test test/app_constants_test.dart`
+Expected: PASS（5 tests passed）
+
+**Step 6: Commit**
+
+```bash
+git add lib/features/foundation/constants/app_constants.dart \
+        lib/features/foundation/foundation.dart \
+        test/app_constants_test.dart
+git commit -m "feat(foundation): add AppConstants for version and AI model info"
+```
+
+---
+
+## Task 3: 擴充 `ChatRepository`：`loadMessages(since:)` 與 `clearAll()`
+
+**Files:**
+- Modify: `lib/data/chat_repository.dart`
+- Test: `integration_test/chat_repository_test.dart`（若不存在則建立；ObjectBox 需 native lib，無法在 unit test 跑）
+
+**Step 1: 修改 `ChatRepository` interface**
+
+在 `lib/data/chat_repository.dart` 修改 abstract interface：
+
+```dart
+abstract interface class ChatRepository {
+  /// Returns up to [_maxMessages] messages ordered newest-first.
+  /// If [since] is provided, only messages with `timestamp > since` are returned.
+  List<ChatMessage> loadMessages({int? since});
+
+  void saveMessage({required ChatMessageRoleEnum role, required String content});
+
+  /// Removes ALL messages from the store. Irreversible.
+  void clearAll();
+
+  void dispose();
+}
+```
+
+**Step 2: 修改 `ChatRepo` 實作**
+
+替換 `loadMessages` 方法：
+
+```dart
+@override
+List<ChatMessage> loadMessages({int? since}) {
+  final builder = since != null
+      ? _box.query(ChatMessage_.timestamp.greaterThan(since))
+      : _box.query();
+  final query = (builder
+        ..order(ChatMessage_.timestamp, flags: Order.descending))
+      .build()
+    ..limit = _maxMessages;
+  try {
+    return query.find();
+  } finally {
+    query.close();
+  }
+}
+```
+
+新增 `clearAll`（放在 `dispose` 之前）：
+
+```dart
+@override
+void clearAll() => _box.removeAll();
+```
+
+**Step 3: 執行 analyze 確認無語法錯誤**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/data/chat_repository.dart`
+Expected: 無 error（warnings 可接受）
+
+**Step 4: 加 integration test（若已有檔案則 append）**
+
+檢查 `integration_test/chat_repository_test.dart` 是否存在：
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && ls integration_test/ 2>/dev/null`
+
+若**不存在**，跳過此 step（單元測試覆蓋率不要求）。
+若**存在**，append 以下兩個 test case：
+
+```dart
+test('loadMessages with since filters older messages', () async {
+  final repo = await ChatRepo.create();
+  final t0 = DateTime.now().millisecondsSinceEpoch;
+  repo.saveMessage(role: ChatMessageRoleEnum.prompt, content: 'old');
+  await Future.delayed(const Duration(milliseconds: 10));
+  final boundary = DateTime.now().millisecondsSinceEpoch;
+  await Future.delayed(const Duration(milliseconds: 10));
+  repo.saveMessage(role: ChatMessageRoleEnum.aiReply, content: 'new');
+
+  final filtered = repo.loadMessages(since: boundary);
+  expect(filtered.length, 1);
+  expect(filtered.first.content, 'new');
+
+  repo.clearAll();
+  repo.dispose();
+});
+
+test('clearAll removes all messages', () async {
+  final repo = await ChatRepo.create();
+  repo.saveMessage(role: ChatMessageRoleEnum.prompt, content: 'a');
+  repo.saveMessage(role: ChatMessageRoleEnum.aiReply, content: 'b');
+  expect(repo.loadMessages().length, greaterThanOrEqualTo(2));
+
+  repo.clearAll();
+  expect(repo.loadMessages(), isEmpty);
+
+  repo.dispose();
+});
+```
+
+**Step 5: 全專案 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && make analyze_lint`
+Expected: 無新增 error
+
+**Step 6: Commit**
+
+```bash
+git add lib/data/chat_repository.dart integration_test/ 2>/dev/null || \
+  git add lib/data/chat_repository.dart
+git commit -m "feat(data): add since filter to loadMessages and clearAll method"
+```
+
+---
+
+## Task 4: 新增 BLoC events `GeminiApiNewChatEvent` 與 `GeminiApiClearAllEvent`
+
+**Files:**
+- Modify: `lib/bloc/gemini_api/gemini_api_event.dart`
+
+**Step 1: 在 event 檔尾端新增兩個 event 類別**
+
+修改 `lib/bloc/gemini_api/gemini_api_event.dart`，在 `class GeminiApiRemoveFileEvent extends GeminiApiEvent {}` 之後新增：
+
+```dart
+class GeminiApiNewChatEvent extends GeminiApiEvent {}
+
+class GeminiApiClearAllEvent extends GeminiApiEvent {}
+```
+
+**Step 2: 執行 analyze 確認語法**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/bloc/gemini_api/gemini_api_event.dart`
+Expected: 無 error
+
+**Step 3: Commit**
+
+```bash
+git add lib/bloc/gemini_api/gemini_api_event.dart
+git commit -m "feat(bloc): add GeminiApiNewChatEvent and GeminiApiClearAllEvent"
+```
+
+---
+
+## Task 5: 修改 `_init` 支援 session 邊界
+
+**Files:**
+- Modify: `lib/bloc/gemini_api/gemini_api_bloc.dart`
+
+**Step 1: 在檔頂新增 import**
+
+在 `lib/bloc/gemini_api/gemini_api_bloc.dart` 的 imports 區塊新增：
+
+```dart
+import 'package:shared_preferences/shared_preferences.dart';
+```
+
+**Step 2: 在 class 內新增 SharedPreferences key 常數**
+
+在 `class GeminiApiBloc` 內、`_base64ImagePattern` 之後新增：
+
+```dart
+static const String _sessionStartKey = 'session_start_ms';
+```
+
+**Step 3: 修改 `_init` 函式（讀取 session 邊界）**
+
+替換 `_init` 內容：
+
+```dart
+void _init(GeminiApiInitEvent event, Emitter<GeminiApiState> emit) async {
+  final prefs = await SharedPreferences.getInstance();
+  final sessionStartMs = prefs.getInt(_sessionStartKey);
+
+  _chatList = _repo.loadMessages(since: sessionStartMs).map((m) {
+    return switch (m.roleEnum) {
+      ChatMessageRoleEnum.prompt  => ChatEntryPrefix.prompt.wrap(m.content),
+      ChatMessageRoleEnum.aiReply => ChatEntryPrefix.aiReply.wrap(m.content),
+      _                           => ChatEntryPrefix.error.wrap(m.content),
+    };
+  }).toList();
+
+  await _initFirebaseAiLogic();
+  emit(state.copyWith(chatList: _chatList.isEmpty ? null : _chatList));
+}
+```
+
+**Step 4: 執行 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/bloc/gemini_api/gemini_api_bloc.dart`
+Expected: 無 error
+
+**Step 5: Commit**
+
+```bash
+git add lib/bloc/gemini_api/gemini_api_bloc.dart
+git commit -m "feat(bloc): filter loaded messages by session_start_ms boundary"
+```
+
+---
+
+## Task 6: 新增 `_newChat` handler
+
+**Files:**
+- Modify: `lib/bloc/gemini_api/gemini_api_bloc.dart`
+
+**Step 1: 註冊 event handler**
+
+在 `GeminiApiBloc` constructor 中、`on<GeminiApiRemoveFileEvent>(_removeFile);` 之後新增：
+
+```dart
+on<GeminiApiNewChatEvent>(_newChat);
+```
+
+**Step 2: 實作 `_newChat`**
+
+在 `_removeFile` 之後新增：
+
+```dart
+Future<void> _newChat(
+  GeminiApiNewChatEvent event,
+  Emitter<GeminiApiState> emit,
+) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setInt(_sessionStartKey, DateTime.now().millisecondsSinceEpoch);
+  _chatList = [];
+  emit(state.copyWith(
+    status: Status.initial,
+    chatList: null,
+    clearFile: true,
+  ));
+}
+```
+
+**Step 3: 執行 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/bloc/gemini_api/gemini_api_bloc.dart`
+Expected: 無 error
+
+**Step 4: Commit**
+
+```bash
+git add lib/bloc/gemini_api/gemini_api_bloc.dart
+git commit -m "feat(bloc): add _newChat handler writes session_start_ms and clears UI"
+```
+
+---
+
+## Task 7: 新增 `_clearAll` handler
+
+**Files:**
+- Modify: `lib/bloc/gemini_api/gemini_api_bloc.dart`
+
+**Step 1: 註冊 event handler**
+
+在 constructor 中、`on<GeminiApiNewChatEvent>(_newChat);` 之後新增：
+
+```dart
+on<GeminiApiClearAllEvent>(_clearAll);
+```
+
+**Step 2: 實作 `_clearAll`**
+
+在 `_newChat` 之後新增：
+
+```dart
+void _clearAll(
+  GeminiApiClearAllEvent event,
+  Emitter<GeminiApiState> emit,
+) {
+  _repo.clearAll();
+  _chatList = [];
+  emit(state.copyWith(
+    status: Status.initial,
+    chatList: null,
+    clearFile: true,
+  ));
+}
+```
+
+**Step 3: 執行 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/bloc/gemini_api/gemini_api_bloc.dart`
+Expected: 無 error
+
+**Step 4: Commit**
+
+```bash
+git add lib/bloc/gemini_api/gemini_api_bloc.dart
+git commit -m "feat(bloc): add _clearAll handler removes all DB messages and clears UI"
+```
+
+---
+
+## Task 8: 新增 i18n 字串（zh_TW + en）
+
+**Files:**
+- Modify: `lib/l10n/intl_zh_TW.arb`
+- Modify: `lib/l10n/intl_en.arb`
+
+**Step 1: 修改 `intl_zh_TW.arb`**
+
+在最後一個 entry 後（`"goToSettings"` 之後）插入：
+
+```json
+,
+  "menuNewChat": "新對話",
+  "menuClearChat": "清除對話",
+  "menuCopyAll": "複製對話",
+  "menuAbout": "關於",
+  "clearChatTitle": "清除所有對話？",
+  "clearChatContent": "此操作無法復原，所有對話記錄將被永久刪除。",
+  "clearChatConfirm": "清除",
+  "copiedToClipboard": "已複製對話記錄",
+  "aboutDialogVersion": "版本 {version} (build {build})",
+  "@aboutDialogVersion": {
+    "placeholders": {
+      "version": { "type": "String" },
+      "build": { "type": "String" }
+    }
+  },
+  "aboutDialogModel": "AI 模型：{model}",
+  "@aboutDialogModel": {
+    "placeholders": {
+      "model": { "type": "String" }
+    }
+  }
+```
+
+**Step 2: 修改 `intl_en.arb`**
+
+在最後一個 entry 後（`"goToSettings"` 之後）插入：
+
+```json
+,
+  "menuNewChat": "New Chat",
+  "menuClearChat": "Clear Chat",
+  "menuCopyAll": "Copy All",
+  "menuAbout": "About",
+  "clearChatTitle": "Clear all messages?",
+  "clearChatContent": "This action cannot be undone. All conversation history will be permanently deleted.",
+  "clearChatConfirm": "Clear",
+  "copiedToClipboard": "Conversation copied",
+  "aboutDialogVersion": "Version {version} (build {build})",
+  "@aboutDialogVersion": {
+    "placeholders": {
+      "version": { "type": "String" },
+      "build": { "type": "String" }
+    }
+  },
+  "aboutDialogModel": "AI Model: {model}",
+  "@aboutDialogModel": {
+    "placeholders": {
+      "model": { "type": "String" }
+    }
+  }
+```
+
+**Step 3: 確認 JSON 合法**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && python3 -c "import json; json.load(open('lib/l10n/intl_zh_TW.arb'))" && python3 -c "import json; json.load(open('lib/l10n/intl_en.arb'))"`
+Expected: 無輸出（=合法 JSON）
+
+**Step 4: 重新生成 l10n**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && make intl`
+Expected: 重新生成 `lib/generated/l10n.dart`，無 error
+
+**Step 5: 確認 generated key 存在**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && grep -c "menuNewChat\|clearChatTitle\|copiedToClipboard\|aboutDialogVersion" lib/generated/l10n.dart`
+Expected: 數字 ≥ 4
+
+**Step 6: Commit**
+
+```bash
+git add lib/l10n/intl_zh_TW.arb lib/l10n/intl_en.arb lib/generated/l10n.dart
+git commit -m "feat(i18n): add menu and dialog strings for zh_TW and en"
+```
+
+---
+
+## Task 9: 在 `ai_chat_view.dart` 實作 `PopupMenuButton` 骨架
+
+**Files:**
+- Modify: `lib/pages/widgets/ai_chat_view.dart`
+
+**Step 1: 新增 imports**
+
+在現有 imports 區塊新增（注意已有 `flutter/material.dart`）：
+
+```dart
+import 'package:flutter/services.dart'; // Clipboard
+```
+
+**Step 2: 在 `_AiChatViewState` 上方新增 menu action enum**
+
+在檔案 line 12（`class AiChatView extends StatefulWidget` 之前）新增：
+
+```dart
+enum _MenuAction { newChat, clearChat, copyAll, about }
+```
+
+**Step 3: 替換 `more_vert` IconButton 為 PopupMenuButton**
+
+把 `actions: [...]` 內的 IconButton（line 71-74）替換為：
+
+```dart
+actions: [
+  PopupMenuButton<_MenuAction>(
+    icon: const Icon(Icons.more_vert, color: ColorName.color8a000000),
+    onSelected: (action) => _onMenuSelected(context, action),
+    itemBuilder: (_) => [
+      PopupMenuItem(
+        value: _MenuAction.newChat,
+        child: Row(children: [
+          const Icon(Icons.add_comment_outlined),
+          const SizedBox(width: Sizes.paddingS),
+          Text(S.current.menuNewChat),
+        ]),
+      ),
+      PopupMenuItem(
+        value: _MenuAction.clearChat,
+        child: Row(children: [
+          const Icon(Icons.delete_outline),
+          const SizedBox(width: Sizes.paddingS),
+          Text(S.current.menuClearChat),
+        ]),
+      ),
+      PopupMenuItem(
+        value: _MenuAction.copyAll,
+        child: Row(children: [
+          const Icon(Icons.copy_outlined),
+          const SizedBox(width: Sizes.paddingS),
+          Text(S.current.menuCopyAll),
+        ]),
+      ),
+      const PopupMenuDivider(),
+      PopupMenuItem(
+        value: _MenuAction.about,
+        child: Row(children: [
+          const Icon(Icons.info_outline),
+          const SizedBox(width: Sizes.paddingS),
+          Text(S.current.menuAbout),
+        ]),
+      ),
+    ],
+  ),
+],
+```
+
+**Step 4: 在 `_AiChatViewState` 加入 `_onMenuSelected` 路由（先放空殼）**
+
+在 `_scrollToBottom` 之前（或檔尾、build 方法外）新增：
+
+```dart
+void _onMenuSelected(BuildContext context, _MenuAction action) {
+  switch (action) {
+    case _MenuAction.newChat:
+      context.read<GeminiApiBloc>().add(GeminiApiNewChatEvent());
+      break;
+    case _MenuAction.clearChat:
+      _confirmClearChat(context);
+      break;
+    case _MenuAction.copyAll:
+      _copyAllMessages(context);
+      break;
+    case _MenuAction.about:
+      _showAboutDialog(context);
+      break;
+  }
+}
+
+void _confirmClearChat(BuildContext context) {
+  // Implemented in Task 10
+}
+
+void _copyAllMessages(BuildContext context) {
+  // Implemented in Task 11
+}
+
+void _showAboutDialog(BuildContext context) {
+  // Implemented in Task 12
+}
+```
+
+**Step 5: 執行 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/pages/widgets/ai_chat_view.dart`
+Expected: 可能會 warning「方法為空」，但無 error
+
+**Step 6: Commit**
+
+```bash
+git add lib/pages/widgets/ai_chat_view.dart
+git commit -m "feat(ui): add PopupMenuButton skeleton with 4 menu items and routing"
+```
+
+---
+
+## Task 10: 實作「清除對話」確認 Dialog
+
+**Files:**
+- Modify: `lib/pages/widgets/ai_chat_view.dart`
+
+**Step 1: 替換 `_confirmClearChat`**
+
+```dart
+void _confirmClearChat(BuildContext context) {
+  showDialog<void>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      title: Text(S.current.clearChatTitle),
+      content: Text(S.current.clearChatContent),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(),
+          child: Text(S.current.cancel),
+        ),
+        TextButton(
+          onPressed: () {
+            context.read<GeminiApiBloc>().add(GeminiApiClearAllEvent());
+            Navigator.of(dialogContext).pop();
+          },
+          style: TextButton.styleFrom(foregroundColor: Colors.red),
+          child: Text(S.current.clearChatConfirm),
+        ),
+      ],
+    ),
+  );
+}
+```
+
+**Step 2: 執行 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/pages/widgets/ai_chat_view.dart`
+Expected: 無 error
+
+**Step 3: Commit**
+
+```bash
+git add lib/pages/widgets/ai_chat_view.dart
+git commit -m "feat(ui): add confirmation dialog for clear chat"
+```
+
+---
+
+## Task 11: 實作「複製對話」
+
+**Files:**
+- Modify: `lib/pages/widgets/ai_chat_view.dart`
+
+**Step 1: 在檔頂新增 import**
+
+```dart
+import '../../bloc/gemini_api/models/chat_entry_prefix.dart';
+```
+
+（若 `bloc/bloc.dart` 已 export `chat_entry_prefix.dart` 則跳過此 step——先檢查：`grep "chat_entry_prefix" lib/bloc/bloc.dart`）
+
+**Step 2: 替換 `_copyAllMessages`**
+
+```dart
+void _copyAllMessages(BuildContext context) {
+  final state = context.read<GeminiApiBloc>().state;
+  final chatList = state.chatList ?? const <String>[];
+
+  final buffer = StringBuffer();
+  // chatList 為 newest-first，reversed 才是時間順序
+  for (final entry in chatList.reversed) {
+    final prefix = ChatEntryPrefix.of(entry);
+    final readable = switch (prefix) {
+      ChatEntryPrefix.prompt  => '👤 You: ${ChatEntryPrefix.prompt.strip(entry)}',
+      ChatEntryPrefix.aiReply => '🤖 Gemini: ${ChatEntryPrefix.aiReply.strip(entry)}',
+      ChatEntryPrefix.error   => '⚠️ Error: ${ChatEntryPrefix.error.strip(entry)}',
+      _                       => entry,
+    };
+    buffer.writeln(readable);
+    buffer.writeln();
+  }
+
+  Clipboard.setData(ClipboardData(text: buffer.toString()));
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(content: Text(S.current.copiedToClipboard)),
+  );
+}
+```
+
+**Step 3: 執行 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/pages/widgets/ai_chat_view.dart`
+Expected: 無 error
+
+**Step 4: Commit**
+
+```bash
+git add lib/pages/widgets/ai_chat_view.dart
+git commit -m "feat(ui): implement copy all messages with readable prefixes"
+```
+
+---
+
+## Task 12: 實作「關於」Dialog
+
+**Files:**
+- Modify: `lib/pages/widgets/ai_chat_view.dart`
+
+**Step 1: 在 imports 加入 features barrel**
+
+確認已 import（若無則加）：
+
+```dart
+import '../../features/features.dart';
+```
+
+或直接 import：
+
+```dart
+import '../../features/foundation/constants/app_constants.dart';
+```
+
+擇一即可（先用 `grep "features/features.dart\|app_constants.dart" lib/pages/widgets/ai_chat_view.dart` 檢查）。
+
+**Step 2: 替換 `_showAboutDialog`**
+
+```dart
+void _showAboutDialog(BuildContext context) {
+  showAboutDialog(
+    context: context,
+    applicationName: S.current.appTitle,
+    applicationVersion: S.current.aboutDialogVersion(
+      AppConstants.appVersion,
+      AppConstants.buildNumber,
+    ),
+    applicationIcon: const CircleAvatar(
+      backgroundColor: ColorName.colorFf673ab7,
+      child: Icon(
+        Icons.auto_awesome,
+        color: ColorName.colorFfffffff,
+      ),
+    ),
+    children: [
+      const SizedBox(height: Sizes.paddingM),
+      Text(S.current.aboutDialogModel(AppConstants.aiModel)),
+      const SizedBox(height: Sizes.paddingS),
+      Text(AppConstants.aiProvider),
+    ],
+  );
+}
+```
+
+**Step 3: 執行 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && dart analyze lib/pages/widgets/ai_chat_view.dart`
+Expected: 無 error
+
+**Step 4: Commit**
+
+```bash
+git add lib/pages/widgets/ai_chat_view.dart
+git commit -m "feat(ui): implement about dialog with version and AI model info"
+```
+
+---
+
+## Task 13: 全專案 lint + 手動驗證
+
+**Files:**
+- 無檔案異動，純驗證
+
+**Step 1: 跑全專案 analyze**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && make analyze_lint`
+Expected: 無新增 error/warning
+
+**Step 2: 跑所有 unit tests**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && flutter test`
+Expected: 全部 PASS
+
+**Step 3: 手動驗證清單（在 device/simulator 上跑 app）**
+
+Run: `cd /Users/yomiry/AiWorkspace/AI-Chat && flutter run`
+
+逐項驗證（參考 `docs/features/20260416-02-25-37-menu-feature-spec.md` § 驗證清單）：
+
+- [ ] 點擊 `more_vert` 顯示 4 個選項，About 與其他間有 Divider
+- [ ] 新對話：畫面清空，DB 資料保留
+- [ ] 新對話：重啟 App 後舊訊息**不**重新出現
+- [ ] 清除對話：Dialog 出現 → 取消不刪除 → 確認後清空畫面 + DB（重啟後也是空）
+- [ ] 複製對話：SnackBar 出現「已複製對話記錄」
+- [ ] 複製對話：剪貼簿內容為時間順序（先 prompt 後 reply），且帶可讀前綴
+- [ ] 複製對話：chatList 為空時，剪貼簿是空字串，SnackBar 仍出現
+- [ ] 關於：Dialog 顯示版本號（與 `pubspec.yaml` 的 `1.0.0+1` 對應）、AI 模型「Gemini 2.5 Flash」、Provider「Google Firebase AI」
+- [ ] 切換語系（zh_TW / en）皆顯示對應字串
+
+**Step 4: 若全部通過，建立 verification commit（無檔案改動可跳過）**
+
+若 manual QA 過程中發現微調，commit 修正；否則直接進 PR 流程。
+
+---
+
+## 完成後
+
+實作全部完成後，執行：
+
+1. `git log --oneline main..HEAD` 確認 commits 連貫
+2. `gh pr create` 建立 PR，描述連結 Issue #23
+
+---
+
+## Plan complete
+
+Plan complete and saved to `docs/plans/2026-04-26-appbar-more-menu-plan.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/lib/bloc/gemini_api/gemini_api_bloc.dart
+++ b/lib/bloc/gemini_api/gemini_api_bloc.dart
@@ -65,7 +65,7 @@ class GeminiApiBloc extends Bloc<GeminiApiEvent, GeminiApiState> {
     _chatList = [];
     emit(state.copyWith(
       status: Status.initial,
-      chatList: null,
+      clearChat: true,
       clearFile: true,
     ));
   }
@@ -78,7 +78,7 @@ class GeminiApiBloc extends Bloc<GeminiApiEvent, GeminiApiState> {
     _chatList = [];
     emit(state.copyWith(
       status: Status.initial,
-      chatList: null,
+      clearChat: true,
       clearFile: true,
     ));
   }

--- a/lib/bloc/gemini_api/gemini_api_bloc.dart
+++ b/lib/bloc/gemini_api/gemini_api_bloc.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:ai_chat/data/data.dart';
 import 'models/models.dart';
 import 'package:ai_chat/features/features.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:firebase_ai/firebase_ai.dart';
@@ -21,6 +22,8 @@ class GeminiApiBloc extends Bloc<GeminiApiEvent, GeminiApiState> {
     r'!\[.*?\]\(data:(image/[^;]+);base64,([A-Za-z0-9+/=]+)\)',
   );
 
+  static const String _sessionStartKey = 'session_start_ms';
+
   late GenerativeModel _aiModel;
   late List<String> _chatList;
   final ChatRepository _repo;
@@ -31,12 +34,17 @@ class GeminiApiBloc extends Bloc<GeminiApiEvent, GeminiApiState> {
     on<GeminiApiPickFileEvent>(_pickFile);
     on<GeminiApiPickImageEvent>(_pickImage);
     on<GeminiApiRemoveFileEvent>(_removeFile);
+    on<GeminiApiNewChatEvent>(_newChat);
+    on<GeminiApiClearAllEvent>(_clearAll);
 
     add(GeminiApiInitEvent());
   }
 
   void _init(GeminiApiInitEvent event, Emitter<GeminiApiState> emit) async {
-    _chatList = _repo.loadMessages().map((m) {
+    final prefs = await SharedPreferences.getInstance();
+    final sessionStartMs = prefs.getInt(_sessionStartKey);
+
+    _chatList = _repo.loadMessages(since: sessionStartMs).map((m) {
       return switch (m.roleEnum) {
         ChatMessageRoleEnum.prompt  => ChatEntryPrefix.prompt.wrap(m.content),
         ChatMessageRoleEnum.aiReply => ChatEntryPrefix.aiReply.wrap(m.content),
@@ -46,6 +54,33 @@ class GeminiApiBloc extends Bloc<GeminiApiEvent, GeminiApiState> {
 
     await _initFirebaseAiLogic();
     emit(state.copyWith(chatList: _chatList.isEmpty ? null : _chatList));
+  }
+
+  Future<void> _newChat(
+    GeminiApiNewChatEvent event,
+    Emitter<GeminiApiState> emit,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_sessionStartKey, DateTime.now().millisecondsSinceEpoch);
+    _chatList = [];
+    emit(state.copyWith(
+      status: Status.initial,
+      chatList: null,
+      clearFile: true,
+    ));
+  }
+
+  void _clearAll(
+    GeminiApiClearAllEvent event,
+    Emitter<GeminiApiState> emit,
+  ) {
+    _repo.clearAll();
+    _chatList = [];
+    emit(state.copyWith(
+      status: Status.initial,
+      chatList: null,
+      clearFile: true,
+    ));
   }
 
   FutureOr<void> _query(

--- a/lib/bloc/gemini_api/gemini_api_event.dart
+++ b/lib/bloc/gemini_api/gemini_api_event.dart
@@ -30,3 +30,8 @@ class GeminiApiPickImageEvent extends GeminiApiEvent {
 }
 
 class GeminiApiRemoveFileEvent extends GeminiApiEvent {}
+
+class GeminiApiNewChatEvent extends GeminiApiEvent {}
+
+class GeminiApiClearAllEvent extends GeminiApiEvent {}
+

--- a/lib/bloc/gemini_api/gemini_api_state.dart
+++ b/lib/bloc/gemini_api/gemini_api_state.dart
@@ -19,12 +19,15 @@ class GeminiApiState extends Equatable {
     Uint8List? selectedFileBytes,
     String? selectedMimeType,
     bool clearFile = false,
+    bool clearChat = false,
   }) {
     return GeminiApiState(
       status: status ?? this.status,
-      chatList: chatList ?? this.chatList,
-      selectedFileBytes: clearFile ? null : (selectedFileBytes ?? this.selectedFileBytes),
-      selectedMimeType: clearFile ? null : (selectedMimeType ?? this.selectedMimeType),
+      chatList: clearChat ? null : (chatList ?? this.chatList),
+      selectedFileBytes:
+          clearFile ? null : (selectedFileBytes ?? this.selectedFileBytes),
+      selectedMimeType:
+          clearFile ? null : (selectedMimeType ?? this.selectedMimeType),
     );
   }
   

--- a/lib/data/chat_repository.dart
+++ b/lib/data/chat_repository.dart
@@ -2,8 +2,15 @@ import '../generated/objectbox/objectbox.g.dart';
 import 'chat_message.dart';
 
 abstract interface class ChatRepository {
-  List<ChatMessage> loadMessages();
+  /// Returns up to [_maxMessages] messages ordered newest-first.
+  /// If [since] is provided, only messages with `timestamp > since` are returned.
+  List<ChatMessage> loadMessages({int? since});
+
   void saveMessage({required ChatMessageRoleEnum role, required String content});
+
+  /// Removes ALL messages from the store. Irreversible.
+  void clearAll();
+
   void dispose();
 }
 
@@ -26,13 +33,19 @@ class ChatRepo implements ChatRepository {
   @override
   void dispose() => _store.close();
 
+  @override
+  void clearAll() => _box.removeAll();
+
   /// Returns up to [_maxMessages] messages ordered newest-first (descending timestamp).
   @override
-  List<ChatMessage> loadMessages() {
+  List<ChatMessage> loadMessages({int? since}) {
+    final builder =
+        since != null
+            ? _box.query(ChatMessage_.timestamp.greaterThan(since))
+            : _box.query();
+
     final query =
-        _box
-            .query()
-            .order(ChatMessage_.timestamp, flags: Order.descending)
+        (builder..order(ChatMessage_.timestamp, flags: Order.descending))
             .build()
           ..limit = _maxMessages;
     try {

--- a/lib/features/foundation/constants/app_constants.dart
+++ b/lib/features/foundation/constants/app_constants.dart
@@ -1,0 +1,8 @@
+class AppConstants {
+  const AppConstants._();
+
+  static const String appVersion = '1.0.0';
+  static const String buildNumber = '1';
+  static const String aiModel = 'Gemini 2.5 Flash';
+  static const String aiProvider = 'Google Firebase AI';
+}

--- a/lib/features/foundation/foundation.dart
+++ b/lib/features/foundation/foundation.dart
@@ -1,2 +1,3 @@
+export 'constants/app_constants.dart';
 export 'extension/extensions.dart';
 export 'style/style.dart';

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -20,18 +20,38 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'en';
 
+  static String m0(model) => "AI Model: ${model}";
+
+  static String m1(version, build) => "Version ${version} (build ${build})";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+    "aboutDialogModel": m0,
+    "aboutDialogVersion": m1,
     "aiAssistantTitle": MessageLookupByLibrary.simpleMessage(
       "Gemini AI Assistant",
     ),
     "appTitle": MessageLookupByLibrary.simpleMessage("AI Chat"),
     "cancel": MessageLookupByLibrary.simpleMessage("Cancel"),
+    "clearChatConfirm": MessageLookupByLibrary.simpleMessage("Clear"),
+    "clearChatContent": MessageLookupByLibrary.simpleMessage(
+      "This action cannot be undone. All conversation history will be permanently deleted.",
+    ),
+    "clearChatTitle": MessageLookupByLibrary.simpleMessage(
+      "Clear all messages?",
+    ),
+    "copiedToClipboard": MessageLookupByLibrary.simpleMessage(
+      "Conversation copied",
+    ),
     "errorLabel": MessageLookupByLibrary.simpleMessage("Error"),
     "goToSettings": MessageLookupByLibrary.simpleMessage("Go to Settings"),
     "howCanIHelp": MessageLookupByLibrary.simpleMessage(
       "How can I help you today?",
     ),
+    "menuAbout": MessageLookupByLibrary.simpleMessage("About"),
+    "menuClearChat": MessageLookupByLibrary.simpleMessage("Clear Chat"),
+    "menuCopyAll": MessageLookupByLibrary.simpleMessage("Copy All"),
+    "menuNewChat": MessageLookupByLibrary.simpleMessage("New Chat"),
     "onlineStatus": MessageLookupByLibrary.simpleMessage("Online"),
     "permissionPhotoDesc": MessageLookupByLibrary.simpleMessage(
       "Please go to system settings and allow this app to access your photo library so you can select images to send to the AI.",

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -20,14 +20,30 @@ typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
 class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'zh_TW';
 
+  static String m0(model) => "AI 模型：${model}";
+
+  static String m1(version, build) => "版本 ${version} (build ${build})";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+    "aboutDialogModel": m0,
+    "aboutDialogVersion": m1,
     "aiAssistantTitle": MessageLookupByLibrary.simpleMessage("Gemini AI 助理"),
     "appTitle": MessageLookupByLibrary.simpleMessage("AI 聊天"),
     "cancel": MessageLookupByLibrary.simpleMessage("取消"),
+    "clearChatConfirm": MessageLookupByLibrary.simpleMessage("清除"),
+    "clearChatContent": MessageLookupByLibrary.simpleMessage(
+      "此操作無法復原，所有對話記錄將被永久刪除。",
+    ),
+    "clearChatTitle": MessageLookupByLibrary.simpleMessage("清除所有對話？"),
+    "copiedToClipboard": MessageLookupByLibrary.simpleMessage("已複製對話記錄"),
     "errorLabel": MessageLookupByLibrary.simpleMessage("錯誤"),
     "goToSettings": MessageLookupByLibrary.simpleMessage("前往設定"),
     "howCanIHelp": MessageLookupByLibrary.simpleMessage("今天能怎麼幫助你？"),
+    "menuAbout": MessageLookupByLibrary.simpleMessage("關於"),
+    "menuClearChat": MessageLookupByLibrary.simpleMessage("清除對話"),
+    "menuCopyAll": MessageLookupByLibrary.simpleMessage("複製對話"),
+    "menuNewChat": MessageLookupByLibrary.simpleMessage("新對話"),
     "onlineStatus": MessageLookupByLibrary.simpleMessage("上線中"),
     "permissionPhotoDesc": MessageLookupByLibrary.simpleMessage(
       "請前往系統設定，允許此 App 存取相片庫，才能選取圖片傳送給 AI。",

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -143,6 +143,86 @@ class S {
       args: [],
     );
   }
+
+  /// `New Chat`
+  String get menuNewChat {
+    return Intl.message('New Chat', name: 'menuNewChat', desc: '', args: []);
+  }
+
+  /// `Clear Chat`
+  String get menuClearChat {
+    return Intl.message(
+      'Clear Chat',
+      name: 'menuClearChat',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Copy All`
+  String get menuCopyAll {
+    return Intl.message('Copy All', name: 'menuCopyAll', desc: '', args: []);
+  }
+
+  /// `About`
+  String get menuAbout {
+    return Intl.message('About', name: 'menuAbout', desc: '', args: []);
+  }
+
+  /// `Clear all messages?`
+  String get clearChatTitle {
+    return Intl.message(
+      'Clear all messages?',
+      name: 'clearChatTitle',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `This action cannot be undone. All conversation history will be permanently deleted.`
+  String get clearChatContent {
+    return Intl.message(
+      'This action cannot be undone. All conversation history will be permanently deleted.',
+      name: 'clearChatContent',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Clear`
+  String get clearChatConfirm {
+    return Intl.message('Clear', name: 'clearChatConfirm', desc: '', args: []);
+  }
+
+  /// `Conversation copied`
+  String get copiedToClipboard {
+    return Intl.message(
+      'Conversation copied',
+      name: 'copiedToClipboard',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Version {version} (build {build})`
+  String aboutDialogVersion(String version, String build) {
+    return Intl.message(
+      'Version $version (build $build)',
+      name: 'aboutDialogVersion',
+      desc: '',
+      args: [version, build],
+    );
+  }
+
+  /// `AI Model: {model}`
+  String aboutDialogModel(String model) {
+    return Intl.message(
+      'AI Model: $model',
+      name: 'aboutDialogModel',
+      desc: '',
+      args: [model],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -10,5 +10,32 @@
   "permissionPhotoTitle": "Photo Access Required",
   "permissionPhotoDesc": "Please go to system settings and allow this app to access your photo library so you can select images to send to the AI.",
   "cancel": "Cancel",
-  "goToSettings": "Go to Settings"
+  "goToSettings": "Go to Settings",
+  "menuNewChat": "New Chat",
+  "menuClearChat": "Clear Chat",
+  "menuCopyAll": "Copy All",
+  "menuAbout": "About",
+  "clearChatTitle": "Clear all messages?",
+  "clearChatContent": "This action cannot be undone. All conversation history will be permanently deleted.",
+  "clearChatConfirm": "Clear",
+  "copiedToClipboard": "Conversation copied",
+  "aboutDialogVersion": "Version {version} (build {build})",
+  "@aboutDialogVersion": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      },
+      "build": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutDialogModel": "AI Model: {model}",
+  "@aboutDialogModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -10,5 +10,32 @@
   "permissionPhotoTitle": "需要相片存取權限",
   "permissionPhotoDesc": "請前往系統設定，允許此 App 存取相片庫，才能選取圖片傳送給 AI。",
   "cancel": "取消",
-  "goToSettings": "前往設定"
+  "goToSettings": "前往設定",
+  "menuNewChat": "新對話",
+  "menuClearChat": "清除對話",
+  "menuCopyAll": "複製對話",
+  "menuAbout": "關於",
+  "clearChatTitle": "清除所有對話？",
+  "clearChatContent": "此操作無法復原，所有對話記錄將被永久刪除。",
+  "clearChatConfirm": "清除",
+  "copiedToClipboard": "已複製對話記錄",
+  "aboutDialogVersion": "版本 {version} (build {build})",
+  "@aboutDialogVersion": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      },
+      "build": {
+        "type": "String"
+      }
+    }
+  },
+  "aboutDialogModel": "AI 模型：{model}",
+  "@aboutDialogModel": {
+    "placeholders": {
+      "model": {
+        "type": "String"
+      }
+    }
+  }
 }

--- a/lib/pages/widgets/ai_chat_view.dart
+++ b/lib/pages/widgets/ai_chat_view.dart
@@ -1,9 +1,11 @@
 import 'package:ai_chat/generated/assets/colors.gen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../bloc/bloc.dart';
-import '../../features/foundation/style/sizes.dart';
+import '../../bloc/gemini_api/models/chat_entry_prefix.dart';
+import '../../features/features.dart';
 import '../../generated/l10n.dart';
 import 'empty_widget.dart';
 import 'input_area_widget.dart';
@@ -16,6 +18,8 @@ class AiChatView extends StatefulWidget {
   @override
   State<AiChatView> createState() => _AiChatViewState();
 }
+
+enum _MenuAction { newChat, clearChat, copyAll, about }
 
 class _AiChatViewState extends State<AiChatView> {
   final ScrollController _scrollController = ScrollController();
@@ -68,9 +72,44 @@ class _AiChatViewState extends State<AiChatView> {
           ],
         ),
         actions: [
-          IconButton(
+          PopupMenuButton<_MenuAction>(
             icon: const Icon(Icons.more_vert, color: ColorName.color8a000000),
-            onPressed: () {},
+            onSelected: (action) => _onMenuSelected(context, action),
+            itemBuilder: (_) => [
+              PopupMenuItem(
+                value: _MenuAction.newChat,
+                child: Row(children: [
+                  const Icon(Icons.add_comment_outlined),
+                  const SizedBox(width: Sizes.paddingS),
+                  Text(S.current.menuNewChat),
+                ]),
+              ),
+              PopupMenuItem(
+                value: _MenuAction.clearChat,
+                child: Row(children: [
+                  const Icon(Icons.delete_outline),
+                  const SizedBox(width: Sizes.paddingS),
+                  Text(S.current.menuClearChat),
+                ]),
+              ),
+              PopupMenuItem(
+                value: _MenuAction.copyAll,
+                child: Row(children: [
+                  const Icon(Icons.copy_outlined),
+                  const SizedBox(width: Sizes.paddingS),
+                  Text(S.current.menuCopyAll),
+                ]),
+              ),
+              const PopupMenuDivider(),
+              PopupMenuItem(
+                value: _MenuAction.about,
+                child: Row(children: [
+                  const Icon(Icons.info_outline),
+                  const SizedBox(width: Sizes.paddingS),
+                  Text(S.current.menuAbout),
+                ]),
+              ),
+            ],
           ),
         ],
       ),
@@ -108,6 +147,31 @@ class _AiChatViewState extends State<AiChatView> {
         },
       ),
     );
+  }
+
+  void _onMenuSelected(BuildContext context, _MenuAction action) {
+    switch (action) {
+      case _MenuAction.newChat:
+        context.read<GeminiApiBloc>().add(GeminiApiNewChatEvent());
+      case _MenuAction.clearChat:
+        _confirmClearChat(context);
+      case _MenuAction.copyAll:
+        _copyAllMessages(context);
+      case _MenuAction.about:
+        _showAboutDialog(context);
+    }
+  }
+
+  void _confirmClearChat(BuildContext context) {
+    // Implemented in Task 10
+  }
+
+  void _copyAllMessages(BuildContext context) {
+    // Implemented in Task 11
+  }
+
+  void _showAboutDialog(BuildContext context) {
+    // Implemented in Task 12
   }
 
   void _scrollToBottom() {

--- a/lib/pages/widgets/ai_chat_view.dart
+++ b/lib/pages/widgets/ai_chat_view.dart
@@ -4,7 +4,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../bloc/bloc.dart';
-import '../../bloc/gemini_api/models/chat_entry_prefix.dart';
 import '../../features/features.dart';
 import '../../generated/l10n.dart';
 import 'empty_widget.dart';

--- a/lib/pages/widgets/ai_chat_view.dart
+++ b/lib/pages/widgets/ai_chat_view.dart
@@ -163,15 +163,73 @@ class _AiChatViewState extends State<AiChatView> {
   }
 
   void _confirmClearChat(BuildContext context) {
-    // Implemented in Task 10
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(S.current.clearChatTitle),
+        content: Text(S.current.clearChatContent),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: Text(S.current.cancel),
+          ),
+          TextButton(
+            onPressed: () {
+              context.read<GeminiApiBloc>().add(GeminiApiClearAllEvent());
+              Navigator.of(dialogContext).pop();
+            },
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(S.current.clearChatConfirm),
+          ),
+        ],
+      ),
+    );
   }
 
   void _copyAllMessages(BuildContext context) {
-    // Implemented in Task 11
+    final state = context.read<GeminiApiBloc>().state;
+    final chatList = state.chatList ?? const <String>[];
+
+    final buffer = StringBuffer();
+    // chatList 為 newest-first，reversed 才是時間順序
+    for (final entry in chatList.reversed) {
+      final prefix = ChatEntryPrefix.of(entry);
+      final readable = switch (prefix) {
+        ChatEntryPrefix.prompt => '👤 You: ${ChatEntryPrefix.prompt.strip(entry)}',
+        ChatEntryPrefix.aiReply =>
+          '🤖 Gemini: ${ChatEntryPrefix.aiReply.strip(entry)}',
+        ChatEntryPrefix.error => '⚠️ Error: ${ChatEntryPrefix.error.strip(entry)}',
+        _ => entry,
+      };
+      buffer.writeln(readable);
+      buffer.writeln();
+    }
+
+    Clipboard.setData(ClipboardData(text: buffer.toString()));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(S.current.copiedToClipboard)),
+    );
   }
 
   void _showAboutDialog(BuildContext context) {
-    // Implemented in Task 12
+    showAboutDialog(
+      context: context,
+      applicationName: S.current.appTitle,
+      applicationVersion: S.current.aboutDialogVersion(
+        AppConstants.appVersion,
+        AppConstants.buildNumber,
+      ),
+      applicationIcon: const CircleAvatar(
+        backgroundColor: ColorName.colorFf673ab7,
+        child: Icon(Icons.auto_awesome, color: ColorName.colorFfffffff),
+      ),
+      children: [
+        const SizedBox(height: Sizes.paddingM),
+        Text(S.current.aboutDialogModel(AppConstants.aiModel)),
+        const SizedBox(height: Sizes.paddingS),
+        Text(AppConstants.aiProvider),
+      ],
+    );
   }
 
   void _scrollToBottom() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   objectbox: ^5.2.0
   objectbox_flutter_libs: ^5.2.0
   collection: ^1.19.1
+  shared_preferences: ^2.3.3
 
 dev_dependencies:
   flutter_test:

--- a/test/app_constants_test.dart
+++ b/test/app_constants_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ai_chat/features/foundation/constants/app_constants.dart';
+
+void main() {
+  group('AppConstants', () {
+    test('appVersion is non-empty', () {
+      expect(AppConstants.appVersion, isNotEmpty);
+    });
+
+    test('buildNumber is non-empty', () {
+      expect(AppConstants.buildNumber, isNotEmpty);
+    });
+
+    test('aiModel is non-empty', () {
+      expect(AppConstants.aiModel, isNotEmpty);
+    });
+
+    test('aiProvider is non-empty', () {
+      expect(AppConstants.aiProvider, isNotEmpty);
+    });
+
+    test('values are correct', () {
+      expect(AppConstants.appVersion, equals('1.0.0'));
+      expect(AppConstants.buildNumber, equals('1'));
+    });
+  });
+}


### PR DESCRIPTION
### Summary
實作 AppBar 選單功能 (New Chat / Clear Chat / Copy All / About)

**[修正問題]**

1. 原本 `ai_chat_view.dart` 中的 `more_vert` 按鈕僅為佔位符，未實作任何功能。
2. 缺乏開啟新對話（保留歷史）與清除對話（刪除歷史）的機制。
3. `GeminiApiState` 的 `copyWith` 實作無法正確處理 `chatList` 為 `null` 的情況，導致即使 BLoC 發出清空指令，UI 列表也不會刷新。

**[修正方式]**

1. **數據層 (Data)**:
   - 在 `ChatRepository` 中新增 `clearAll()` 方法用於硬刪除。
   - 擴充 `loadMessages(since: ...)` 支援時間戳過濾。
2. **邏輯層 (BLoC)**:
   - 加入 `shared_preferences` 紀錄 `session_start_ms` 作為新對話邊界。
   - 新增 `GeminiApiNewChatEvent` (軟刪除) 與 `GeminiApiClearAllEvent` (硬刪除) 處理程序。
   - **關鍵修正**: 在 `GeminiApiState` 加入 `clearChat` 旗標，確保 `copyWith` 能強制清空對話列表。
3. **介面層 (UI)**:
   - 將 `IconButton` 替換為 `PopupMenuButton`。
   - 實作「清除對話」的二次確認對話框。
   - 實作「複製對話」功能，並自動將內部的 `ChatEntryPrefix` 轉換為可讀的 Emoji 前綴。
   - 實作「關於」對話框，顯示 App 版本與 AI 模型資訊。
4. **基礎設施**:
   - 新增 `AppConstants` 管理版本號與模型名稱。
   - 補齊 zh-tw 與 en 的多語系字串。