### PR TITLE
chore: add Qodo Merge (PR-Agent) review config

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,81 @@
+# Qodo Merge (PR-Agent) 設定
+# 對照 .gemini/config.yaml 而來，供 Qodo Merge 雲端版 (GitHub App) 使用。
+#
+# 路線說明（v1 vs v2）：
+# - 本檔走 Qodo v1（Qodo Merge / PR-Agent）路線：審查設定跟著 repo 走，
+#   讀取 repo 根目錄的 .pr_agent.toml + best_practices.md。
+# - Qodo v2（Qodo Review）改用 web dashboard 的 Rule System / Centralized
+#   Governance（線上設定），repo 內這兩個檔是否生效，取決於所安裝的
+#   Qodo GitHub App 版本。若裝的是 v2 而本檔未生效，需改至 Qodo portal 設定。
+# 文件: https://docs.qodo.ai/code-review （舊版設定參考開源 pr-agent 的 configuration.toml）
+
+[pr_reviewer]
+# 對應 .gemini comment_severity_threshold: MEDIUM —— 抑制低價值意見，只留實質問題。
+num_max_findings = 6
+persistent_comment = true
+final_update_message = true
+require_score_review = false
+require_tests_review = true
+require_security_review = true
+extra_instructions = """
+語言與術語：
+- 所有評論必須使用繁體中文 (zh-tw)。
+- 專業術語保留英文原文（例如 Refactoring, Unit Test, Async/Await, Variable, Function, Memory Leak）。
+
+嚴重度：
+- 僅回報 MEDIUM 以上嚴重度的問題，避免吹毛求疵的風格瑣事。
+
+審查依據：
+- 嚴格遵循 repo 根目錄的 best_practices.md（Flutter/Dart Style Guide）作為審查基準。
+
+結尾創作規範（Closing Ritual）：
+- 每次 Code Review 結束時，必須根據審查內容隨機選擇一種「文學體裁」以繁體中文收尾，嚴禁僅使用英文。
+- 支援體裁：
+  - 五言/七言絕句：適合邏輯嚴謹、優雅的修正。
+  - 新詩 (Modern Poetry)：適合抽象的架構建議，使用隱喻。
+  - 俏皮話 (Witty Remarks)：適合抓到 Typos 或小 Bug，語氣幽默風趣。
+  - 順口溜 (Jingles)：適合總結多個修改點，讀起來要有節奏感。
+- 風格範例（供模仿，請勿照抄，依當次審查內容重新創作）：
+  - [五言/七言絕句]：
+    變數命名亂如麻，
+    函式結構需優化。
+    註解清晰如明月，
+    程式碼美如詩。
+  - [新詩]：
+    變數在黑暗中交會
+    沒有宣告的孤獨
+    指向一個不存在的遠方
+    我輕輕補上一行，讓記憶不再迷途。
+  - [俏皮話]：
+    這個 Function 寫得好，效能高到沒煩惱，
+    只是變數命名有點糟，隔壁同事看了會跌倒。
+  - [順口溜]：
+    邏輯通，Bug 噴，程式跑得像火輪。
+    註解多，維護易，這份專案有志氣。
+"""
+
+[pr_description]
+# 對應 .gemini pull_request_opened.summary: true
+publish_description_as_comment = false
+add_original_user_description = true
+generate_ai_title = false
+extra_instructions = """
+- PR 描述使用繁體中文 (zh-tw)，技術術語保留英文原文。
+"""
+
+[pr_code_suggestions]
+# 對應 /improve，會自動載入根目錄的 best_practices.md
+suggestions_score_threshold = 5
+extra_instructions = """
+- 建議內容使用繁體中文 (zh-tw)，技術術語保留英文原文。
+- 嚴格對齊 best_practices.md 的命名、註解、BLoC、Retrofit 與測試規範。
+"""
+
+# 對應 .gemini pull_request_opened —— PR 開啟時自動執行的工具。
+# Qodo Merge 雲端版會讀此段；對應 summary: true + code_review: true。
+[github_app]
+pr_commands = [
+    "/describe",
+    "/review",
+]
+# help: false（不在 PR 開啟時貼說明），對應 .gemini help: false —— 預設即不貼，無需額外設定。

--- a/best_practices.md
+++ b/best_practices.md
@@ -1,0 +1,138 @@
+# Flutter/Dart 專案 Best Practices
+
+本檔供 Qodo Merge 的 `/improve` 與 `/review` 自動載入，作為 Code Review 與程式碼建議的審查基準。
+語言與術語、評論嚴重度、結尾創作規範等 review 行為設定於 `.pr_agent.toml` 的 `extra_instructions`。
+
+Flutter 版本 3.35
+
+## 1. 格式化 (Formatting)
+
+- 始終使用 `dart format` 自動格式化程式碼。
+- 建議行長度限制在 80 個字元以內。
+
+## 2. 命名規範 (Naming Conventions)
+
+- **類別、列舉、型別定義**：使用 `PascalCase`（`MyAwesomeWidget`、`enum Status`、`typedef OnTapCallback`）。
+- **函式、方法、變數**：使用 `camelCase`（`myFunction()`、`String userName`）。
+- **常數**：通常 `camelCase`；全域或跨檔共享可用 `k` 前綴（`kDefaultPadding`）或 `SCREAMING_SNAKE_CASE`（`API_BASE_URL`），皆可接受。
+- **檔案名**：使用 `snake_case`（`my_widget.dart`）。
+- **庫前綴**：命名衝突時用 `snake_case` 前綴（`import 'package:path/path.dart' as p;`）。
+
+### 2.6. 建構式 (Constructors)
+
+- 命名建構式與 factory 建構式皆用 `camelCase`，於類別名稱後加點號（`User.guest()`、`User.fromJson()`）。
+- 成員預設值用 `=` 設定，可在建構式參數或類別成員中設定。
+- **Singleton**：私有建構式 + 靜態實例變數，參考 GetIt 提供靜態 getter `I`。
+
+```dart
+class MySingleton {
+  MySingleton._privateConstructor();
+  static final MySingleton _instance = MySingleton._privateConstructor();
+  factory MySingleton() => _instance;
+  static MySingleton get I => _instance;
+}
+```
+
+## 3. 導入 (Imports)
+
+按 `dart:` → `package:` → relative 順序組織，每區塊以空行分隔。只導入實際需要的庫。
+
+## 4. 註解 (Comments)
+
+### 4.1. 文件註解（使用 `///`）
+
+**必須添加**：對外公開的 API、複雜邏輯、配置類別（如 API 介面）、抽象類別與介面。
+
+**不需添加**：內部實作類別、測試相關類別（Mock 等）、簡單資料類別（Entity / Dto / Model）、BLoC Event 與 State 類別（註解寫在 `*Bloc` class 即可）。
+
+### 4.2. 行內註解（使用 `//`）
+
+解釋複雜或非顯而易見的邏輯。
+
+### 4.3. TODO 註解
+
+使用 `// TODO:` 標記待辦。
+
+## 5. 程式碼結構 (Code Structure)
+
+### 5.1. 類別成員順序
+
+常數 → 靜態變數 → 實例變數 → 建構函式 → 公共方法 → 私有方法 → `build` 方法（Widget）。
+
+### 5.2. 使用 `final` 和 `const`
+
+- 盡可能使用 `final` 提高不可變性與效能。
+- `const` 用於編譯時常數；建構函式不強迫使用 `const`（flutter_lints 5.0.0 已不再強制）。
+
+**⚠️ 規範優先權說明**：本檔為 Qodo Merge 審查參考依據。當與 `.agents/rules/flutter-rules.md` 的編碼規則衝突時（如 const 使用程度），以各自工具的適用範圍為準：Qodo 審查依本檔判準，AI agent 編碼遵循 `.agents/rules` 規範。
+
+### 5.3. 避免深層巢狀
+
+以提取方法、衛語句 (guard clauses) 等方式降低巢狀深度。
+
+```dart
+// Good
+void func() {
+  if (user == null || !user.isActive) return;
+  doSomething();
+}
+```
+
+## 6. 錯誤處理 (Error Handling)
+
+對可能拋出異常的程式碼使用 `try-catch`，並針對具體例外型別處理（`on FormatException catch (e)`）。
+
+## 7. Flutter 特定建議
+
+- **Widget 拆分**：將複雜 Widget 拆成更小、單一職責、可重用的 Widget。
+- **`const` 建構函式**：已於 flutter_lints 5.0.0 deprecated，不再強制。
+- **避免在 `build` 中執行昂貴操作**：將計算/網路請求移至 `initState`、`didChangeDependencies` 或狀態管理層。
+- **資源管理**：正確釋放 `AnimationController`、`StreamSubscription` 等。
+
+### 7.4. 狀態管理 (State Management)
+
+選擇 **BLoC** 作為主要狀態管理方案。
+
+- 每個 BLoC 專注單一職責 (SRP)；以 Events 觸發狀態變更、以 State 表示 UI 狀態；BLoC 與 UI 分離。
+- BLoC 命名具描述性（`GetCartCountBloc`）。
+- 為每個 BLoC 編寫單元測試，使用 `bloc_test`。
+- **BLoC Events**：
+  - 用 `abstract class` 定義事件基類，子類為具體事件。
+  - 使用 `equatable`，覆寫 `props` 包含所有相關屬性（基於內容而非引用比較）。
+  - 事件與 Bloc 同前綴（`CartBloc` → `CartLoad`）。
+  - 避免 Query 事件處理過多邏輯：建議在 Bloc 中以私有方法 `_onCompleted`、`_onFailed` 處理（符合 BLoC 規範，避免事件迴圈）。
+
+## 8. 測試 (Testing)
+
+- 至少編寫單元測試；Widget 測試與整合測試為可選。
+- 測資與測試邏輯分離，放在同檔的 `_Data` class。
+- 通用測資放 `test/mock/mock_common_message.dart` 供多檔共用。
+- 測試函式名稱清楚描述目的，以 `test` / `group` 組織。
+
+## Y. 其他
+
+- **避免魔術數字/字串**：重複使用的數字或字串定義為具名常數（測試除外）。
+- **保持函式簡潔**：每個函式只做一件事。
+- **Logger 規則**：使用 `logger` 套件，依環境設定日誌等級。`Logger().d` 為 debug mode only，release 不輸出。
+
+## X. AI Review Decisions
+
+### X.1. Retrofit
+
+依 Domain 拆分不同 API，透過 Dio 管理 Base URL、Headers、Interceptors，使用 Retrofit 生成 API 客戶端。
+
+- 不在 `@RestApi()` 使用 `baseUrl` 參數（由 Dio 統一管理）。
+- Path 宣告需含 `/` 前綴，不在 `@GET`、`@POST` 重複 Base URL。
+
+```dart
+@RestApi()
+abstract class UserApi {
+  @GET('/users')
+  Future<List<User>> getUsers();
+}
+```
+
+### X.2. DTO / Entity / Model 轉換
+
+- 大多數情境建議透過 `fromJson` / `toJson` 完成轉換以減少程式碼（接受 type safety 的取捨）。
+- 僅在需要複雜轉換或更高效能時，才直接在建構函式中映射欄位。


### PR DESCRIPTION
### Summary
[#22](https://github.com/Yomiamy/AI-Chat/issues/22) Qodo Merge config support

**[修正問題]**

專案目前缺乏自動化 PR 審查機制。每次開 PR 時需仰賴人工 Code Review，且沒有統一的 Flutter/Dart 審查基準文件，導致審查品質不一致、缺少繁體中文的回饋產出。

**[修正方式]**

1. 新增 `.pr_agent.toml`，設定 Qodo Merge (PR-Agent) 在 PR 開啟時自動執行 `/describe` 與 `/review`。
2. 設定 `[pr_reviewer]` 區段：限制最大 findings 數為 6、啟用測試與安全審查、嚴重度過濾至 MEDIUM 以上、全數以繁體中文 (zh-tw) 輸出、加入結尾創作規範（五言/七言絕句、新詩、俏皮話、順口溜）。
3. 設定 `[pr_description]` 與 `[pr_code_suggestions]` 區段：PR 描述與程式碼建議均以繁體中文產出，對齊 `best_practices.md` 規範。
4. 新增 `best_practices.md`，涵蓋 Flutter/Dart 格式化、命名、導入、註解、程式碼結構、錯誤處理、Widget 拆分、BLoC 狀態管理、測試、Retrofit 與 DTO 轉換等審查基準，供 Qodo Merge `/review` 與 `/improve` 載入。